### PR TITLE
Fix TypeError when processing exceptions with null repeatEnd

### DIFF
--- a/src/EventListener/DataContainer/CalendarEventsCallbacks.php
+++ b/src/EventListener/DataContainer/CalendarEventsCallbacks.php
@@ -299,7 +299,7 @@ class CalendarEventsCallbacks extends Backend
             $this->processExtendedRecurring($activeRecord, $arrSet, $arrAllRecurrences, $maxRepeatEnd);
 
         // process exceptions
-        $currentEndDate = \count($maxRepeatEnd) > 1 ? max($maxRepeatEnd) : $arrSet['repeatEnd'];
+        $currentEndDate = \count($maxRepeatEnd) > 1 ? (int) max($maxRepeatEnd) : (int) ($arrSet['repeatEnd'] ?? 0);
         [$exceptionList, $maxRepeatEnd] =
             $this->processExceptions($activeRecord, $currentEndDate, $maxRepeatEnd);
         $arrSet['exceptionList'] = $exceptionList;


### PR DESCRIPTION
Cast computed repeat-end to `int` (fallback `0`) so `processExceptions()` always receives an `int`. Prevents crash during imports/frontend rendering when `repeatEnd` is unset.